### PR TITLE
Implemented simple matrix type with 2D indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ For example the functions `cblas_saxpy`, `cblas_daxpy`, `cblas_caxypy`, and
 Additionally, RBLAS introduces a few traits to shorten calls to these BLAS
 functions: `Vector` for types that implement vector-like characteristics and
 `Matrix` for types that implement matrix-like characteristics. The `Vector`
-trait is already implemented by `Vec` and `[]` types.
+trait is already implemented by `Vec` and `[]` types. The `Matrix` trait
+is implemented by a simple wrapper around `Vec` that allows creating
+a sized matrix and use 2-dimensional indexing.
 
 [Documentation](http://mikkyang.github.io/rust-blas/doc/rblas/index.html)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use matrix::Matrix;
 pub use vector::ops::*;
 pub use matrix_vector::ops::*;
 pub use matrix::ops::*;
+pub use matrix::Mat;
 
 #[macro_use]
 mod prefix;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -26,6 +26,50 @@ pub trait BandMatrix<T>: Matrix<T> {
     fn sup_diagonals(&self) -> i32;
 }
 
+pub struct Mat<T> {
+    data: Vec<T>,
+    rows: usize,
+    cols: usize
+}
+
+impl<T> Mat<T> {
+    fn new(n: usize, m: usize) -> Mat<T> {
+        let mut data = Vec::<T>::with_capacity(n*m);
+        unsafe{ data.set_len(n*m); }
+        Mat::<T> { data: data, rows: n, cols: m }
+    }
+}
+
+use std::ops::Index;
+use std::ops::IndexMut;
+
+impl<T> Index<usize> for Mat<T> {
+    type Output = [T];
+
+    fn index(&self, idx: &usize) -> &[T] {
+        let beg = *idx * self.rows;
+        let end = beg+self.cols;
+        &self.data[beg..end]
+    }
+}
+
+impl<T> IndexMut<usize> for Mat<T> {
+    type Output = [T];
+
+    fn index_mut(&mut self, idx: &usize) -> &mut [T] {
+        let beg = *idx * self.rows;
+        let end = beg+self.cols;
+        &mut self.data[beg..end]
+    }
+}
+
+impl<T> Matrix<T> for Mat<T> {
+    fn rows(&self) -> i32 { self.rows as i32 }
+    fn cols(&self) -> i32 { self.cols as i32 }
+    fn as_ptr(&self) -> *const T { self.data.as_ptr() }
+    fn as_mut_ptr(&mut self) -> *mut T { self.data.as_mut_ptr() }
+}
+
 #[cfg(test)]
 mod test_struct {
     use matrix::Matrix;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -55,7 +55,6 @@ impl<T> Index<usize> for Mat<T> {
 }
 
 impl<T> IndexMut<usize> for Mat<T> {
-    type Output = [T];
 
     fn index_mut(&mut self, idx: &usize) -> &mut [T] {
         let beg = *idx * self.rows;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -39,6 +39,14 @@ impl<T> Mat<T> {
         unsafe{ data.set_len(n*m); }
         Mat::<T> { data: data, rows: n, cols: m }
     }
+
+    fn as_slice(&self) -> &[T] {
+        self.data.as_slice()
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        self.data.as_mut_slice()
+    }
 }
 
 use std::ops::Index;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -26,6 +26,7 @@ pub trait BandMatrix<T>: Matrix<T> {
     fn sup_diagonals(&self) -> i32;
 }
 
+#[derive(Clone, PartialEq)]
 pub struct Mat<T> {
     data: Vec<T>,
     rows: usize,

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -49,8 +49,7 @@ impl<T> Mat<T> {
     }
 }
 
-use std::ops::Index;
-use std::ops::IndexMut;
+use std::ops::{Index, IndexMut};
 
 impl<T> Index<usize> for Mat<T> {
     type Output = [T];
@@ -99,6 +98,32 @@ mod test_struct {
         #[inline]
         fn as_mut_ptr(&mut self) -> *mut T {
             self.2.as_mut_slice().as_mut_ptr()
+        }
+    }
+}
+
+#[test]
+fn mat_test() {
+    let mut A = Mat::<f64>::new(3,3);
+    //fill matrix
+    for i in range(0,3) {
+        for j in range(0,3) {
+            A[i][j] = ((i*3+j) as f64)
+        }
+
+    }
+    //test clone and eq
+    let B = A.clone();
+    assert!(A == B);
+    A[0][0] = 10f64;
+    assert!(A != B);
+    //check if indexing worked and row of A is as expected
+    let row0 = vec![10f64, 1f64, 2f64];
+    assert_eq!(row0.as_slice(), &A[0]);
+    //check B did not change
+    for i in range(0,3) {
+        for j in range(0,3) {
+            assert_eq!(B[i][j], ((i*3+j) as f64));
         }
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -34,18 +34,18 @@ pub struct Mat<T> {
 }
 
 impl<T> Mat<T> {
-    fn new(m: usize, n: usize) -> Mat<T> {
+    pub fn new(m: usize, n: usize) -> Mat<T> {
         let len = m*n;
         let mut data = Vec::<T>::with_capacity(len);
         unsafe{ data.set_len(len); }
         Mat::<T> { data: data, rows: m, cols: n }
     }
 
-    fn as_slice(&self) -> &[T] {
+    pub fn as_slice(&self) -> &[T] {
         self.data.as_slice()
     }
 
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.data.as_mut_slice()
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -34,10 +34,11 @@ pub struct Mat<T> {
 }
 
 impl<T> Mat<T> {
-    fn new(n: usize, m: usize) -> Mat<T> {
-        let mut data = Vec::<T>::with_capacity(n*m);
-        unsafe{ data.set_len(n*m); }
-        Mat::<T> { data: data, rows: n, cols: m }
+    fn new(m: usize, n: usize) -> Mat<T> {
+        let len = m*n;
+        let mut data = Vec::<T>::with_capacity(len);
+        unsafe{ data.set_len(len); }
+        Mat::<T> { data: data, rows: m, cols: n }
     }
 
     fn as_slice(&self) -> &[T] {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -92,7 +92,7 @@ impl<'a, T> Vector<T> for &'a [T] {
 
     #[inline]
     fn len(&self) -> i32 {
-        let l: Option<i32> = NumCast::from(self.len());
+        let l: Option<i32> = NumCast::from((*self).len());
         match l {
             Some(l) => l,
             None => panic!(),


### PR DESCRIPTION
I have added a simple matrix type that wraps a vector and implements your Matrix trait. It allows use like
let A = Mat::<f64>::new(4,4);
A[0][1] = 1f64;
...
and since A[i] yields a slice rows can also be used as a vector.
This is some of my first rust code ever so I hope it's not too bad.
