### PR TITLE
configurable cblas library?

### DIFF
--- a/src/matrix/ll.rs
+++ b/src/matrix/ll.rs
@@ -14,7 +14,7 @@ use attribute::{
     Side,
 };
 
-#[link(name = "blas")]
+#[link(name = "openblas")]
 extern {
     // Multiply
     pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);

--- a/src/matrix_vector/ll.rs
+++ b/src/matrix_vector/ll.rs
@@ -13,7 +13,7 @@ use attribute::{
     Diagonal,
 };
 
-#[link(name = "blas")]
+#[link(name = "openblas")]
 extern {
     // Multiply
     pub fn cblas_sgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);

--- a/src/vector/ll.rs
+++ b/src/vector/ll.rs
@@ -6,7 +6,7 @@
 
 use libc::{c_double, c_float, c_int, c_void, size_t};
 
-#[link(name = "blas")]
+#[link(name = "openblas")]
 extern {
     // Copy
     pub fn cblas_scopy(n: c_int, x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);


### PR DESCRIPTION
Hi, thanks for writing this wrapper @mikkyang! It seems very intuitive and lacks the extra cruft found in some other ports.

As it stands, I was unable to use this library. In my system "libblas" links to the (fortran?) blas library which has a different interface than the cblas library. Note that the [blas](http://www.netlib.org/blas/#_blas_routines) functions dont have the "cblas_" prefix. The linker couldn't find the functions I wanted to use.

In order to get your code working, I had to link against "cblas" instead. You'll notice I linked against [openblas](https://github.com/xianyi/OpenBLAS) instead of cblas in this pull request. There may be other implementations of blas that users of this port may want to use too. I don't suggest merging this pull, or making a new pull linking to "cblas" instead of "openblas". I think a better solution is to let the user decide which library (with the cblas interface) they want to link to. I'm thinking some sort of ENV variable used in the macros, and if the env-var is not defined, use "cblas" as default.

Thanks again for the port! I'm very new to rust, but if you want this change and you're not feeling up to making this change, I'd be willing to give it a shot. Also, I'm curious if your projects work if you link to "cblas" instead of "blas". I think "cblas" is the proper library to be linking to. 
