### PR TITLE
Fix rblas to build on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ build = "build.rs"
 
 [dependencies]
 num = "*"
+libc = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 #![feature(concat_idents)]
 #![feature(raw)]
-#![feature(libc)]
 
 //! BLAS bindings and wrappers.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 #![feature(concat_idents)]
+#![feature(raw)]
 #![feature(libc)]
 
 //! BLAS bindings and wrappers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 #![feature(concat_idents)]
-#![feature(core)]
 #![feature(libc)]
 
 //! BLAS bindings and wrappers.
@@ -20,7 +19,6 @@
 //! * Level 2: `matrix_vector`
 //! * Level 3: `matrix`
 
-extern crate core;
 extern crate libc;
 extern crate num;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 #![feature(concat_idents)]
-#![feature(raw)]
 
 //! BLAS bindings and wrappers.
 //!

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -5,9 +5,8 @@
 
 use std::fmt;
 use std::iter::repeat;
-use std::mem;
 use std::ops::Index;
-use std::raw;
+use std::slice;
 use num::traits::NumCast;
 use Matrix;
 use Vector;
@@ -61,7 +60,7 @@ impl<T> Index<usize> for Mat<T> {
 
         unsafe {
             let ptr = (&self.data[..]).as_ptr().offset(offset);
-            mem::transmute(raw::Slice { data: ptr, len: self.cols })
+            slice::from_raw_parts(ptr, self.cols)
         }
     }
 }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -4,7 +4,6 @@
 
 //! Vector operations.
 
-use std::raw::Repr;
 use num::traits::NumCast;
 use num::complex::{Complex32, Complex64};
 use vector::ops::{Copy, Axpy, Scal, Dot, Nrm2, Asum, Iamax};
@@ -97,7 +96,7 @@ impl<'a, T> Vector<T> for &'a [T] {
 
     #[inline]
     fn len(&self) -> i32 {
-        let l: Option<i32> = NumCast::from((*self).len());
+        let l: Option<i32> = NumCast::from(<&[T]>::len(self));
         match l {
             Some(l) => l,
             None => panic!(),
@@ -105,10 +104,10 @@ impl<'a, T> Vector<T> for &'a [T] {
     }
 
     #[inline]
-    unsafe fn as_ptr(&self) -> *const T { self.repr().data }
+    unsafe fn as_ptr(&self) -> *const T { <&[T]>::as_ptr(self) }
 
     #[inline]
-    unsafe fn as_mut_ptr(&mut self) -> *mut T { self.repr().data as *mut T }
+    unsafe fn as_mut_ptr(&mut self) -> *mut T { <&[T]>::as_mut_ptr(self) }
 }
 
 macro_rules! operations_impl(

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -5,7 +5,6 @@
 //! Vector operations.
 
 use std::raw::Repr;
-use core::slice::SliceExt;
 use num::traits::NumCast;
 use num::complex::{Complex32, Complex64};
 use vector::ops::{Copy, Axpy, Scal, Dot, Nrm2, Asum, Iamax};
@@ -98,7 +97,7 @@ impl<'a, T> Vector<T> for &'a [T] {
 
     #[inline]
     fn len(&self) -> i32 {
-        let l: Option<i32> = NumCast::from(SliceExt::len(*self));
+        let l: Option<i32> = NumCast::from((*self).len());
         match l {
             Some(l) => l,
             None => panic!(),


### PR DESCRIPTION
Currently `rblas` is not building with the rust nightly due to changes in features. I made a few changes to get things to build as well as migrating unstable features to stable APIs with the same functionality.

The code now builds on nightly rust as of today (2015-07-13) and all the tests pats. The only thing that is keeping it from building on stable and beta is the `concat_idents!` feature gate.
