### PR TITLE
Remove concat_ident! for module expressions, enable building on stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2014 Michael Yang. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
-#![feature(concat_idents)]
 
 //! BLAS bindings and wrappers.
 //!

--- a/src/matrix/ll.rs
+++ b/src/matrix/ll.rs
@@ -4,55 +4,122 @@
 
 //! Bindings for matrix functions.
 
-use libc::{c_double, c_float, c_int, c_void};
+pub mod cblas_s {
+    use libc::{c_float, c_int};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
-use attribute::{
-    Order,
-    Transpose,
-    Symmetry,
-    Diagonal,
-    Side,
-};
+    pub use self::cblas_sgemm as gemm;
+    pub use self::cblas_ssymm as symm;
+    pub use self::cblas_strmm as trmm;
+    pub use self::cblas_strsm as strsm;
+    pub use self::cblas_ssyrk as syrk;
+    pub use self::cblas_ssyr2k as syr2k;
 
-extern {
-    // Multiply
-    pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-    pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_double,      a: *const c_double, lda: c_int, b: *const c_double, ldb: c_int, beta: c_double,      c: *mut c_double, ldc: c_int);
-    pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-    pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+    extern {
+        pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
+        pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
+        pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *mut c_float,  ldb: c_int);
+        pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *mut c_float,  ldb: c_int);
+        pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
+        pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
+    }
+}
 
-    pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-    pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: c_double,      a: *const c_double, lda: c_int, b: *const c_double, ldb: c_int, beta: c_double,      c: *mut c_double, ldc: c_int);
-    pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-    pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+pub mod cblas_d {
+    use libc::{c_double, c_int};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
-    pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-    pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+    pub use self::cblas_dgemm as gemm;
+    pub use self::cblas_dsymm as symm;
+    pub use self::cblas_dtrmm as trmm;
+    pub use self::cblas_dtrsm as strsm;
+    pub use self::cblas_dsyrk as syrk;
+    pub use self::cblas_dsyr2k as syr2k;
 
-    pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *mut c_float,  ldb: c_int);
-    pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_double,      a: *const c_double, lda: c_int, b: *mut c_double, ldb: c_int);
-    pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
-    pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
+    extern {
+        pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *const c_double,  ldb: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
+        pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *const c_double,  ldb: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
+        pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *mut c_double,  ldb: c_int);
+        pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *mut c_double,  ldb: c_int);
+        pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
+        pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *const c_double,  ldb: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
+    }
+}
 
-    pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *mut c_float,  ldb: c_int);
-    pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_double,      a: *const c_double, lda: c_int, b: *mut c_double, ldb: c_int);
-    pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
-    pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
+pub mod cblas_c {
+    use libc::{c_float, c_int, c_void};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
-    // Rank Update
-    pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,  a: *const c_void, lda: c_int, beta: c_float,  c: *mut c_void, ldc: c_int);
-    pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double, a: *const c_void, lda: c_int, beta: c_double, c: *mut c_void, ldc: c_int);
+    pub use self::cblas_cgemm as gemm;
+    pub use self::cblas_csymm as symm;
+    pub use self::cblas_chemm as hemm;
+    pub use self::cblas_ctrmm as trmm;
+    pub use self::cblas_ctrsm as trsm;
+    pub use self::cblas_cherk as herk;
+    pub use self::cblas_cher2k as her2k;
+    pub use self::cblas_csyrk as syrk;
+    pub use self::cblas_csyr2k as syr2k;
 
-    pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void, lda: c_int, b: *const c_void, ldb: c_int, beta: c_float,  c: *mut c_void, ldc: c_int);
-    pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void, lda: c_int, b: *const c_void, ldb: c_int, beta: c_double, c: *mut c_void, ldc: c_int);
+    extern {
+        pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
+        pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
+        pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,  a: *const c_void, lda: c_int, beta: c_float,  c: *mut c_void, ldc: c_int);
+        pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void, lda: c_int, b: *const c_void, ldb: c_int, beta: c_float,  c: *mut c_void, ldc: c_int);
+        pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+    }
+}
 
-    pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-    pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double,      a: *const c_double, lda: c_int, beta: c_double,      c: *mut c_double, ldc: c_int);
-    pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-    pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+pub mod cblas_z {
+    use libc::{c_double, c_int, c_void};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
-    pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-    pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double,      a: *const c_double, lda: c_int, b: *const c_double, ldb: c_int, beta: c_double,      c: *mut c_double, ldc: c_int);
-    pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-    pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+    pub use self::cblas_zgemm as gemm;
+    pub use self::cblas_zsymm as symm;
+    pub use self::cblas_zhemm as hemm;
+    pub use self::cblas_ztrmm as trmm;
+    pub use self::cblas_ztrsm as trsm;
+    pub use self::cblas_zherk as herk;
+    pub use self::cblas_zher2k as her2k;
+    pub use self::cblas_zsyrk as syrk;
+    pub use self::cblas_zsyr2k as syr2k;
+
+    extern {
+        pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
+        pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
+        pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double, a: *const c_void, lda: c_int, beta: c_double, c: *mut c_void, ldc: c_int);
+        pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void, lda: c_int, b: *const c_void, ldb: c_int, beta: c_double, c: *mut c_void, ldc: c_int);
+        pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+    }
 }

--- a/src/matrix_vector/ll.rs
+++ b/src/matrix_vector/ll.rs
@@ -4,111 +4,194 @@
 
 //! Bindings for matrix-vector functions.
 
-use libc::{c_double, c_float, c_int, c_void};
+pub mod cblas_s {
+    use libc::{c_float, c_int};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+    };
 
-use attribute::{
-    Order,
-    Transpose,
-    Symmetry,
-    Diagonal,
-};
+    pub use self::cblas_sgemv as gemv;
+    pub use self::cblas_ssymv as symv;
+    pub use self::cblas_strmv as trmv;
+    pub use self::cblas_strsv as trsv;
+    pub use self::cblas_sger as ger;
+    pub use self::cblas_ssyr as syr;
+    pub use self::cblas_ssyr2 as syr2;
+    pub use self::cblas_sspmv as spmv;
+    pub use self::cblas_sgbmv as gbmv;
+    pub use self::cblas_ssbmv as sbmv;
+    pub use self::cblas_stbmv as tbmv;
+    pub use self::cblas_stbsv as tbsv;
+    pub use self::cblas_stpmv as tpmv;
+    pub use self::cblas_stpsv as tpsv;
+    pub use self::cblas_sspr as spr;
+    pub use self::cblas_sspr2 as spr2;
 
-extern {
-    // Multiply
-    pub fn cblas_sgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_double,      a: *const c_double, lda: c_int, x: *const c_double, inc_x: c_int, beta: c_double,      y: *mut c_double, inc_y: c_int);
-    pub fn cblas_cgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+    extern {
+        pub fn cblas_sgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_ssymv(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  lda: c_int, x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  lda: c_int, x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_sger (order: Order, m: c_int, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float,  lda: c_int);
+        pub fn cblas_ssyr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_float,  inc_x: c_int, a: *mut c_float,  lda: c_int);
+        pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float,  lda: c_int);
+        pub fn cblas_sspmv(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_sgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_sspr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_float,  inc_x: c_int, a: *mut c_float);
+        pub fn cblas_sspr2(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float);
+    }
+}
 
-    pub fn cblas_ssymv(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dsymv(order: Order, sym: Symmetry, n: c_int, alpha: c_double,      a: *const c_double, lda: c_int, x: *const c_double, inc_x: c_int, beta: c_double,      y: *mut c_double, inc_y: c_int);
-    pub fn cblas_csymv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zsymv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+pub mod cblas_d {
+    use libc::{c_double, c_int};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+    };
 
-    pub fn cblas_chemv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zhemv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+    pub use self::cblas_dgemv as gemv;
+    pub use self::cblas_dsymv as symv;
+    pub use self::cblas_dtrmv as trmv;
+    pub use self::cblas_dtrsv as trsv;
+    pub use self::cblas_dger as ger;
+    pub use self::cblas_dsyr as syr;
+    pub use self::cblas_dsyr2 as syr2;
+    pub use self::cblas_dspmv as spmv;
+    pub use self::cblas_dgbmv as gbmv;
+    pub use self::cblas_dsbmv as sbmv;
+    pub use self::cblas_dtbmv as tbmv;
+    pub use self::cblas_dtbsv as tbsv;
+    pub use self::cblas_dtpmv as tpmv;
+    pub use self::cblas_dtpsv as tpsv;
+    pub use self::cblas_dspr as spr;
+    pub use self::cblas_dspr2 as spr2;
 
-    pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  lda: c_int, x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double, lda: c_int, x: *mut c_double, inc_x: c_int);
-    pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
+    extern {
+        pub fn cblas_dgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
+        pub fn cblas_dsymv(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
+        pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  lda: c_int, x: *mut c_double,  inc_x: c_int);
+        pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  lda: c_int, x: *mut c_double,  inc_x: c_int);
+        pub fn cblas_dger (order: Order, m: c_int, n: c_int, alpha: c_double,       x: *const c_double,  inc_x: c_int, y: *const c_double,  inc_y: c_int, a: *mut c_double,  lda: c_int);
+        pub fn cblas_dsyr(order: Order, sym: Symmetry, n: c_int, alpha: c_double,  x: *const c_double,  inc_x: c_int, a: *mut c_double,  lda: c_int);
+        pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       x: *const c_double,  inc_x: c_int, y: *const c_double,  inc_y: c_int, a: *mut c_double,  lda: c_int);
+        pub fn cblas_dspmv(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       a: *const c_double,  x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
+        pub fn cblas_dgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
+        pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
+        pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
+        pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
+        pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
+        pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
+        pub fn cblas_dspr(order: Order, sym: Symmetry, n: c_int, alpha: c_double,  x: *const c_double,  inc_x: c_int, a: *mut c_double);
+        pub fn cblas_dspr2(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       x: *const c_double,  inc_x: c_int, y: *const c_double,  inc_y: c_int, a: *mut c_double);
+    }
+}
 
-    pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  lda: c_int, x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double, lda: c_int, x: *mut c_double, inc_x: c_int);
-    pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
+pub mod cblas_c {
+    use libc::{c_float, c_int, c_void};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+    };
 
-    // Rank Update
-    pub fn cblas_sger (order: Order, m: c_int, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float,  lda: c_int);
-    pub fn cblas_dger (order: Order, m: c_int, n: c_int, alpha: c_double,      x: *const c_double, inc_x: c_int, y: *const c_double, inc_y: c_int, a: *mut c_double, lda: c_int);
+    pub use self::cblas_cgemv as gemv;
+    pub use self::cblas_csymv as symv;
+    pub use self::cblas_chemv as hemv;
+    pub use self::cblas_ctrmv as trmv;
+    pub use self::cblas_ctrsv as trsv;
+    pub use self::cblas_cgeru as geru;
+    pub use self::cblas_cgerc as gerc;
+    pub use self::cblas_cher as her;
+    pub use self::cblas_cher2 as her2;
+    pub use self::cblas_cgbmv as gbmv;
+    pub use self::cblas_chbmv as hbmv;
+    pub use self::cblas_ctbmv as tbmv;
+    pub use self::cblas_ctbsv as tbsv;
+    pub use self::cblas_chpmv as hpmv;
+    pub use self::cblas_ctpmv as tpmv;
+    pub use self::cblas_ctpsv as tpsv;
+    pub use self::cblas_chpr as hpr;
+    pub use self::cblas_chpr2 as hpr2;
 
-    pub fn cblas_cgeru(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-    pub fn cblas_zgeru(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+    extern {
+        pub fn cblas_cgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_csymv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_chemv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_cgeru(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_cgerc(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_cher(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_void,   inc_x: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_cher2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_cgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_chbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_chpmv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_chpr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_void,   inc_x: c_int, a: *mut c_void);
+        pub fn cblas_chpr2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void);
+    }
+}
 
-    pub fn cblas_cgerc(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-    pub fn cblas_zgerc(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+pub mod cblas_z {
+    use libc::{c_double, c_int, c_void};
+    use attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+    };
 
-    pub fn cblas_cher(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_void,   inc_x: c_int, a: *mut c_void,   lda: c_int);
-    pub fn cblas_zher(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_void,   inc_x: c_int, a: *mut c_void,   lda: c_int);
+    pub use self::cblas_zgemv as gemv;
+    pub use self::cblas_zsymv as symv;
+    pub use self::cblas_zhemv as hemv;
+    pub use self::cblas_ztrmv as trmv;
+    pub use self::cblas_ztrsv as trsv;
+    pub use self::cblas_zgeru as geru;
+    pub use self::cblas_zgerc as gerc;
+    pub use self::cblas_zher as her;
+    pub use self::cblas_zher2 as her2;
+    pub use self::cblas_zgbmv as gbmv;
+    pub use self::cblas_zhbmv as hbmv;
+    pub use self::cblas_ztbmv as tbmv;
+    pub use self::cblas_ztbsv as tbsv;
+    pub use self::cblas_zhpmv as hpmv;
+    pub use self::cblas_ztpmv as tpmv;
+    pub use self::cblas_ztpsv as tpsv;
+    pub use self::cblas_zhpr as hpr;
+    pub use self::cblas_zhpr2 as hpr2;
 
-    pub fn cblas_ssyr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_float,  inc_x: c_int, a: *mut c_float,  lda: c_int);
-    pub fn cblas_dsyr(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_double, inc_x: c_int, a: *mut c_double, lda: c_int);
-
-    pub fn cblas_cher2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-    pub fn cblas_zher2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-
-    pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float,  lda: c_int);
-    pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: c_int, alpha: c_double,      x: *const c_double, inc_x: c_int, y: *const c_double, inc_y: c_int, a: *mut c_double, lda: c_int);
-
-    // Band Multiply
-    pub fn cblas_sgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: c_double,      a: *const c_double, lda: c_int, x: *const c_double, inc_x: c_int, beta: c_double,      y: *mut c_double, inc_y: c_int);
-    pub fn cblas_cgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-
-    pub fn cblas_chbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-
-    pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: c_double,      a: *const c_double, lda: c_int, x: *const c_double, inc_x: c_int, beta: c_double,      y: *mut c_double, inc_y: c_int);
-
-    pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_double, x: *mut c_double, inc_x: c_int);
-    pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-
-    pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_double, x: *mut c_double, inc_x: c_int);
-    pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-
-    // Packed Multiply
-    pub fn cblas_chpmv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-
-    pub fn cblas_sspmv(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dspmv(order: Order, sym: Symmetry, n: c_int, alpha: c_double,      a: *const c_double, x: *const c_double, inc_x: c_int, beta: c_double,      y: *mut c_double, inc_y: c_int);
-
-    pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double, x: *mut c_double, inc_x: c_int);
-    pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-
-    pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double, x: *mut c_double, inc_x: c_int);
-    pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-
-    // Packed Rank Update
-    pub fn cblas_chpr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_void,   inc_x: c_int, a: *mut c_void);
-    pub fn cblas_zhpr(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_void,   inc_x: c_int, a: *mut c_void);
-
-    pub fn cblas_sspr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_float,  inc_x: c_int, a: *mut c_float);
-    pub fn cblas_dspr(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_double, inc_x: c_int, a: *mut c_double);
-
-    pub fn cblas_chpr2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void);
-    pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void);
-
-    pub fn cblas_sspr2(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float);
-    pub fn cblas_dspr2(order: Order, sym: Symmetry, n: c_int, alpha: c_double,      x: *const c_double, inc_x: c_int, y: *const c_double, inc_y: c_int, a: *mut c_double);
+    extern {
+        pub fn cblas_zgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_zsymv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_zhemv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_zgeru(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_zgerc(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_zher(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_void,   inc_x: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_zher2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
+        pub fn cblas_zgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_zhpr(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_void,   inc_x: c_int, a: *mut c_void);
+        pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void);
+    }
 }

--- a/src/matrix_vector/ops.rs
+++ b/src/matrix_vector/ops.rs
@@ -167,7 +167,7 @@ pub trait Gerc: Ger {
 }
 
 macro_rules! ger_impl(
-    ($trait_name: ident, $fn_name: ident, $t: ty, $ger_fn: ident) => (
+    ($trait_name: ident, $fn_name: ident, $t: ty, $ger_fn: expr) => (
         impl $trait_name for $t {
             fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &$t, x: &V, y: &W, a: &mut Matrix<$t>) {
                 unsafe {
@@ -183,15 +183,15 @@ macro_rules! ger_impl(
     );
 );
 
-ger_impl!(Ger, ger, f32,       cblas_sger);
-ger_impl!(Ger, ger, f64,       cblas_dger);
-ger_impl!(Ger, ger, Complex32, cblas_cgeru);
-ger_impl!(Ger, ger, Complex64, cblas_zgeru);
+ger_impl!(Ger, ger, f32,       cblas_s::ger);
+ger_impl!(Ger, ger, f64,       cblas_d::ger);
+ger_impl!(Ger, ger, Complex32, cblas_c::geru);
+ger_impl!(Ger, ger, Complex64, cblas_z::geru);
 
 impl Gerc for f32 {}
 impl Gerc for f64 {}
-ger_impl!(Gerc, gerc, Complex32, cblas_cgerc);
-ger_impl!(Gerc, gerc, Complex64, cblas_zgerc);
+ger_impl!(Gerc, gerc, Complex32, cblas_c::gerc);
+ger_impl!(Gerc, gerc, Complex64, cblas_z::gerc);
 
 #[cfg(test)]
 mod ger_tests {

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -3,10 +3,10 @@
 // license that can be found in the LICENSE file.
 
 macro_rules! prefix(
-    (f32, $f: ident) => (concat_idents!(cblas_s, $f));
-    (f64, $f: ident) => (concat_idents!(cblas_d, $f));
-    (Complex<f32>, $f: ident) => (concat_idents!(cblas_c, $f));
-    (Complex<f64>, $f: ident) => (concat_idents!(cblas_z, $f));
-    (Complex32, $f: ident) => (concat_idents!(cblas_c, $f));
-    (Complex64, $f: ident) => (concat_idents!(cblas_z, $f));
+    (f32, $f: ident) => (cblas_s::$f);
+    (f64, $f: ident) => (cblas_d::$f);
+    (Complex<f32>, $f: ident) => (cblas_c::$f);
+    (Complex<f64>, $f: ident) => (cblas_z::$f);
+    (Complex32, $f: ident) => (cblas_c::$f);
+    (Complex64, $f: ident) => (cblas_z::$f);
 );

--- a/src/vector/ll.rs
+++ b/src/vector/ll.rs
@@ -4,76 +4,134 @@
 
 //! Bindings for vector functions.
 
-use libc::{c_double, c_float, c_int, c_void, size_t};
+pub mod cblas_s {
+    use libc::{c_float, c_int, c_void};
 
-extern {
-    // Copy
-    pub fn cblas_scopy(n: c_int, x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dcopy(n: c_int, x: *const c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
-    pub fn cblas_ccopy(n: c_int, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zcopy(n: c_int, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+    pub use self::cblas_scopy as copy;
+    pub use self::cblas_saxpy as axpy;
+    pub use self::cblas_sscal as scal;
+    pub use self::cblas_sswap as swap;
+    pub use self::cblas_sdsdot as dsdot;
+    pub use self::cblas_sdot as dot;
+    pub use self::cblas_sasum as asum;
+    pub use self::cblas_scasum as casum;
+    pub use self::cblas_snrm2 as nrm2;
+    pub use self::cblas_scnrm2 as cnrm2;
+    pub use self::cblas_srot as rot;
+    pub use self::cblas_srotm as rotm;
+    pub use self::cblas_srotg as rotg;
+    pub use self::cblas_srotmg as rotmg;
 
-    // Update
-    pub fn cblas_saxpy(n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_daxpy(n: c_int, alpha: c_double,      x: *const c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
-    pub fn cblas_caxpy(n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zaxpy(n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+    extern {
+        pub fn cblas_scopy(n: c_int, x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_saxpy(n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_sscal(n: c_int, alpha: c_float,       x: *mut c_float,  inc_x: c_int);
+        pub fn cblas_sswap(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
+        pub fn cblas_sdsdot(n: c_int, alpha: c_float, x: *const c_float, inc_x: c_int, y: *const c_float, inc_y: c_int) -> c_float;
+        pub fn cblas_sdot(n: c_int, x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int) -> c_float;
+        pub fn cblas_sasum(n: c_int, x: *const c_float,  inc_x: c_int) -> c_float;
+        pub fn cblas_scasum(n: c_int, x: *const c_void,   inc_x: c_int) -> c_float;
+        pub fn cblas_snrm2(n: c_int, x: *const c_float,  inc_x: c_int) -> c_float;
+        pub fn cblas_scnrm2(n: c_int, x: *const c_void,   inc_x: c_int) -> c_float;
+        pub fn cblas_srot(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int, c: c_float,  s: c_float);
+        pub fn cblas_srotm(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int, p: *const c_float);
+        pub fn cblas_srotg(a: *mut c_float,  b: *mut c_float,  c: *mut c_float,  s: *mut c_float);
+        pub fn cblas_srotmg(d1: *mut c_float,  d2: *mut c_float,  b1: *mut c_float,  b2: c_float,  p: *mut c_float);
+    }
+}
 
-    // Scale
-    pub fn cblas_sscal (n: c_int, alpha: c_float,       x: *mut c_float,  inc_x: c_int);
-    pub fn cblas_dscal (n: c_int, alpha: c_double,      x: *mut c_double, inc_x: c_int);
-    pub fn cblas_cscal (n: c_int, alpha: *const c_void, x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_zscal (n: c_int, alpha: *const c_void, x: *mut c_void,   inc_x: c_int);
+pub mod cblas_d {
+    use libc::{c_double, c_float, c_int, c_void};
 
-    pub fn cblas_csscal(n: c_int, alpha: c_float,       x: *mut c_void,   inc_x: c_int);
-    pub fn cblas_zdscal(n: c_int, alpha: c_double,      x: *mut c_void,   inc_x: c_int);
+    pub use self::cblas_dcopy as copy;
+    pub use self::cblas_daxpy as axpy;
+    pub use self::cblas_dscal as scal;
+    pub use self::cblas_dswap as swap;
+    pub use self::cblas_dsdot as dsdot;
+    pub use self::cblas_ddot as dot;
+    pub use self::cblas_dasum as asum;
+    pub use self::cblas_dzasum as zasum;
+    pub use self::cblas_dnrm2 as nrm2;
+    pub use self::cblas_dznrm2 as znrm2;
+    pub use self::cblas_drot as rot;
+    pub use self::cblas_drotm as rotm;
+    pub use self::cblas_drotg as rotg;
+    pub use self::cblas_drotmg as rotmg;
 
-    // Switch
-    pub fn cblas_sswap(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
-    pub fn cblas_dswap(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
-    pub fn cblas_cswap(n: c_int, x: *mut c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-    pub fn cblas_zswap(n: c_int, x: *mut c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+    extern {
+        pub fn cblas_dcopy(n: c_int, x: *const c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
+        pub fn cblas_daxpy(n: c_int, alpha: c_double,      x: *const c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
+        pub fn cblas_dscal (n: c_int, alpha: c_double,      x: *mut c_double, inc_x: c_int);
+        pub fn cblas_dswap(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
+        pub fn cblas_dsdot(n: c_int, x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int) -> c_double;
+        pub fn cblas_ddot (n: c_int, x: *const c_double, inc_x: c_int, y: *const c_double, inc_y: c_int) -> c_double;
+        pub fn cblas_dasum (n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
+        pub fn cblas_dzasum(n: c_int, x: *const c_void,   inc_x: c_int) -> c_double;
+        pub fn cblas_dnrm2 (n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
+        pub fn cblas_dznrm2(n: c_int, x: *const c_void,   inc_x: c_int) -> c_double;
+        pub fn cblas_drot(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int, c: c_double, s: c_double);
+        pub fn cblas_drotm(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int, p: *const c_double);
+        pub fn cblas_drotg(a: *mut c_double, b: *mut c_double, c: *mut c_double, s: *mut c_double);
+        pub fn cblas_drotmg(d1: *mut c_double, d2: *mut c_double, b1: *mut c_double, b2: c_double, p: *mut c_double);
+    }
+}
 
-    // Dot Product
-    pub fn cblas_sdsdot(n: c_int, alpha: c_float, x: *const c_float, inc_x: c_int, y: *const c_float, inc_y: c_int) -> c_float;
+pub mod cblas_c {
+    use libc::{c_float, c_int, c_void};
 
-    pub fn cblas_dsdot(n: c_int, x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int) -> c_double;
+    pub use self::cblas_ccopy as copy;
+    pub use self::cblas_caxpy as axpy;
+    pub use self::cblas_cscal as scal;
+    pub use self::cblas_csscal as sscal;
+    pub use self::cblas_cswap as swap;
+    pub use self::cblas_cdotu_sub as dotu_sub;
+    pub use self::cblas_cdotc_sub as dotc_sub;
 
-    pub fn cblas_sdot (n: c_int, x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int) -> c_float;
-    pub fn cblas_ddot (n: c_int, x: *const c_double, inc_x: c_int, y: *const c_double, inc_y: c_int) -> c_double;
+    extern {
+        pub fn cblas_ccopy(n: c_int, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_caxpy(n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_cscal (n: c_int, alpha: *const c_void, x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_csscal(n: c_int, alpha: c_float,       x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_cswap(n: c_int, x: *mut c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_cdotu_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotu: *mut c_void);
+        pub fn cblas_cdotc_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotc: *mut c_void);
+    }
+}
 
-    pub fn cblas_cdotu_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotu: *mut c_void);
-    pub fn cblas_zdotu_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotu: *mut c_void);
+pub mod cblas_z {
+    use libc::{c_double, c_int, c_void};
 
-    pub fn cblas_cdotc_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotc: *mut c_void);
-    pub fn cblas_zdotc_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotc: *mut c_void);
+    pub use self::cblas_zcopy as copy;
+    pub use self::cblas_zaxpy as axpy;
+    pub use self::cblas_zscal as scal;
+    pub use self::cblas_zdscal as dscal;
+    pub use self::cblas_zswap as swap;
+    pub use self::cblas_zdotu_sub as dotu_sub;
+    pub use self::cblas_zdotc_sub as dotc_sub;
 
-    // Norm
-    pub fn cblas_sasum (n: c_int, x: *const c_float,  inc_x: c_int) -> c_float;
-    pub fn cblas_dasum (n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
-    pub fn cblas_scasum(n: c_int, x: *const c_void,   inc_x: c_int) -> c_float;
-    pub fn cblas_dzasum(n: c_int, x: *const c_void,   inc_x: c_int) -> c_double;
+    extern {
+        pub fn cblas_zcopy(n: c_int, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_zaxpy(n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_zscal (n: c_int, alpha: *const c_void, x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_zdscal(n: c_int, alpha: c_double,      x: *mut c_void,   inc_x: c_int);
+        pub fn cblas_zswap(n: c_int, x: *mut c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
+        pub fn cblas_zdotu_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotu: *mut c_void);
+        pub fn cblas_zdotc_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotc: *mut c_void);
+    }
+}
 
-    pub fn cblas_snrm2 (n: c_int, x: *const c_float,  inc_x: c_int) -> c_float;
-    pub fn cblas_dnrm2 (n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
-    pub fn cblas_scnrm2(n: c_int, x: *const c_void,   inc_x: c_int) -> c_float;
-    pub fn cblas_dznrm2(n: c_int, x: *const c_void,   inc_x: c_int) -> c_double;
+pub mod cblas_i {
+    use libc::{c_double, c_float, c_int, c_void, size_t};
 
-    pub fn cblas_isamax(n: c_int, x: *const c_float,  inc_x: c_int) -> size_t;
-    pub fn cblas_idamax(n: c_int, x: *const c_double, inc_x: c_int) -> size_t;
-    pub fn cblas_icamax(n: c_int, x: *const c_void,   inc_x: c_int) -> size_t;
-    pub fn cblas_izamax(n: c_int, x: *const c_void,   inc_x: c_int) -> size_t;
+    pub use self::cblas_isamax as samax;
+    pub use self::cblas_idamax as damax;
+    pub use self::cblas_icamax as camax;
+    pub use self::cblas_izamax as zamax;
 
-    // Rotate
-    pub fn cblas_srot(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int, c: c_float,  s: c_float);
-    pub fn cblas_drot(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int, c: c_double, s: c_double);
-
-    pub fn cblas_srotm(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int, p: *const c_float);
-    pub fn cblas_drotm(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int, p: *const c_double);
-
-    pub fn cblas_srotg(a: *mut c_float,  b: *mut c_float,  c: *mut c_float,  s: *mut c_float);
-    pub fn cblas_drotg(a: *mut c_double, b: *mut c_double, c: *mut c_double, s: *mut c_double);
-
-    pub fn cblas_srotmg(d1: *mut c_float,  d2: *mut c_float,  b1: *mut c_float,  b2: c_float,  p: *mut c_float);
-    pub fn cblas_drotmg(d1: *mut c_double, d2: *mut c_double, b1: *mut c_double, b2: c_double, p: *mut c_double);
+    extern {
+        pub fn cblas_isamax(n: c_int, x: *const c_float,  inc_x: c_int) -> size_t;
+        pub fn cblas_idamax(n: c_int, x: *const c_double, inc_x: c_int) -> size_t;
+        pub fn cblas_icamax(n: c_int, x: *const c_void,   inc_x: c_int) -> size_t;
+        pub fn cblas_izamax(n: c_int, x: *const c_void,   inc_x: c_int) -> size_t;
+    }
 }

--- a/src/vector/ops.rs
+++ b/src/vector/ops.rs
@@ -411,7 +411,7 @@ macro_rules! real_norm_impl(($trait_name: ident, $fn_name: ident, $($t: ident), 
 ));
 
 macro_rules! complex_norm_impl(
-    ($trait_name: ident, $fn_name: ident, $t: ty, $norm_fn: ident) => (
+    ($trait_name: ident, $fn_name: ident, $t: ty, $norm_fn: expr) => (
         impl $trait_name for $t {
             fn $fn_name<V: ?Sized + Vector<Self>>(x: &V) -> $t {
                 let re = unsafe {
@@ -427,10 +427,10 @@ macro_rules! complex_norm_impl(
 
 real_norm_impl!(Asum, asum, f32, f64);
 real_norm_impl!(Nrm2, nrm2, f32, f64);
-complex_norm_impl!(Asum, asum, Complex32, cblas_scasum);
-complex_norm_impl!(Asum, asum, Complex64, cblas_dzasum);
-complex_norm_impl!(Nrm2, nrm2, Complex32, cblas_scnrm2);
-complex_norm_impl!(Nrm2, nrm2, Complex64, cblas_dznrm2);
+complex_norm_impl!(Asum, asum, Complex32, cblas_s::casum);
+complex_norm_impl!(Asum, asum, Complex64, cblas_d::zasum);
+complex_norm_impl!(Nrm2, nrm2, Complex32, cblas_s::cnrm2);
+complex_norm_impl!(Nrm2, nrm2, Complex64, cblas_d::znrm2);
 
 #[cfg(test)]
 mod asum_tests {
@@ -498,7 +498,7 @@ pub trait Iamax: Sized {
 }
 
 macro_rules! iamax_impl(
-    ($t: ty, $iamax: ident) => (
+    ($t: ty, $iamax: expr) => (
         impl Iamax for $t {
             fn iamax<V: ?Sized + Vector<Self>>(x: &V) -> usize {
                 unsafe {
@@ -510,10 +510,10 @@ macro_rules! iamax_impl(
     );
 );
 
-iamax_impl!(f32,       cblas_isamax);
-iamax_impl!(f64,       cblas_idamax);
-iamax_impl!(Complex32, cblas_icamax);
-iamax_impl!(Complex64, cblas_izamax);
+iamax_impl!(f32,       cblas_i::samax);
+iamax_impl!(f64,       cblas_i::damax);
+iamax_impl!(Complex32, cblas_i::camax);
+iamax_impl!(Complex64, cblas_i::zamax);
 
 #[cfg(test)]
 mod iamax_tests {


### PR DESCRIPTION
Enables rust-blas to build on Rust stable.

This sorts the function prototypes in the FFI by group, and changes the `prefix!` and similar macros to using the new modules instead of `concat_indent!`.

The future of `concat_ident!` is uncertain: https://github.com/rust-lang/rust/issues/29599
