### PR TITLE
Use only feature `complex` from num

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-num = "0.1"
+num = { version = "0.1", default-features = false, features = ["complex"] }
 libc = "0.2"


### PR DESCRIPTION
This way we don't have to compile rand, rustc-serialize and some unused parts of num.
